### PR TITLE
Ensure headless Chrome usage

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -39,6 +39,9 @@ class DOUScraper:
         chrome_options.add_experimental_option("prefs", prefs)
         user_data_dir = mkdtemp()
         chrome_options.add_argument(f"--user-data-dir={user_data_dir}")
+        chrome_options.add_argument("--headless")
+        chrome_options.add_argument("--no-sandbox")
+        chrome_options.add_argument("--disable-dev-shm-usage")
         self.driver = webdriver.Chrome(options=chrome_options)
         self.wait = WebDriverWait(self.driver, 20)
 


### PR DESCRIPTION
## Summary
- enable headless Chrome in scraper

## Testing
- `python -m py_compile scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_686fbd68e7bc8321ad9c6a6f54b13a20