### PR TITLE
Fix download for Google Sheets

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -26,8 +26,9 @@ jobs:
       - name: ⚙️ Decodifica credenciais e executa o script
         env:
           GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
-          EXCEL_FILE_NAME: ${{ secrets.EXCEL_FILE_NAME }}
+          TERMS_FILE_ID: ${{ secrets.TERMS_FILE_ID }}
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          SERVICE_ACCOUNT_FILE: servicescraperdou.json
         run: |
-          echo "$SERVICE_ACCOUNT_JSON" | base64 --decode > service_account.json
+          echo "$SERVICE_ACCOUNT_JSON" | base64 --decode > "$SERVICE_ACCOUNT_FILE"
           python main.py

--- a/drive_uploader.py
+++ b/drive_uploader.py
@@ -3,6 +3,7 @@ import os
 import mimetypes
 import io
 import json
+import base64
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 from google.oauth2 import service_account
@@ -18,7 +19,11 @@ SERVICE_ACCOUNT_FILE = os.getenv("SERVICE_ACCOUNT_FILE", "servicescraperdou.json
 if not os.path.exists(SERVICE_ACCOUNT_FILE):
     service_json_content = os.getenv("SERVICE_ACCOUNT_JSON")
     if service_json_content:
-        json_data = json.loads(service_json_content)
+        try:
+            json_data = json.loads(service_json_content)
+        except json.JSONDecodeError:
+            decoded = base64.b64decode(service_json_content).decode("utf-8")
+            json_data = json.loads(decoded)
         if "private_key" in json_data:
             json_data["private_key"] = json_data["private_key"].replace("\\n", "\n")
         with open(SERVICE_ACCOUNT_FILE, "w") as f:
@@ -29,16 +34,17 @@ def authenticate_service():
         SERVICE_ACCOUNT_FILE,
         scopes=SCOPES
     )
-    return build('drive', 'v3', credentials=credentials)
+    return build('drive', 'v3', credentials=credentials, cache_discovery=False)
 
 def upload_to_drive(file_path):
     service = authenticate_service()
     file_name = os.path.basename(file_path)
     mime_type, _ = mimetypes.guess_type(file_path)
 
+    drive_folder = os.getenv("DRIVE_FOLDER_ID") or os.getenv("GOOGLE_DRIVE_FOLDER_ID")
     file_metadata = {
         'name': file_name,
-        'parents': [os.getenv("DRIVE_FOLDER_ID")]
+        'parents': [drive_folder] if drive_folder else []
     }
     media = MediaFileUpload(file_path, mimetype=mime_type)
 
@@ -58,15 +64,34 @@ def upload_to_drive(file_path):
     return link
 
 def download_file_from_drive(file_id, output_path):
+    """Download a file from Google Drive.
+
+    If the file is a native Google document (e.g. a spreadsheet), it will be
+    exported to a suitable format before saving locally.
+    """
     service = authenticate_service()
-    request = service.files().get_media(fileId=file_id)
-    fh = io.FileIO(output_path, 'wb')
+
+    meta = service.files().get(fileId=file_id, fields="mimeType,name").execute()
+    mime_type = meta.get("mimeType", "")
+
+    if mime_type == "application/vnd.google-apps.spreadsheet":
+        request = service.files().export_media(
+            fileId=file_id,
+            mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    elif mime_type.startswith("application/vnd.google-apps"):
+        request = service.files().export_media(fileId=file_id, mimeType="application/pdf")
+    else:
+        request = service.files().get_media(fileId=file_id)
+
+    fh = io.FileIO(output_path, "wb")
     downloader = MediaIoBaseDownload(fh, request)
 
     done = False
     while not done:
         status, done = downloader.next_chunk()
-        print(f"Download {int(status.progress() * 100)}%.")
+        if status:
+            print(f"Download {int(status.progress() * 100)}%.")
 
     return output_path
 


### PR DESCRIPTION
## Summary
- handle export when downloading Google Drive native files
- support DRIVE_FOLDER_ID or GOOGLE_DRIVE_FOLDER_ID
- disable Drive discovery cache

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6883ebbd8aa883219a79592f112c404b