### PR TITLE
Improve Drive download error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ docker run --rm -v $PWD:/app scraperdou
 ## Variáveis e arquivos secretos
 - `servicescraperdou.json` (não subir no GitHub)
 - `credentials.json` (não subir no GitHub)
+- Variável de ambiente `TERMS_FILE_ID` com o ID da planilha de termos no Google Drive
 
 **Importante:** Verifique permissões e IDs de arquivos/pastas usados no Google Drive.

--- a/drive_uploader.py
+++ b/drive_uploader.py
@@ -69,6 +69,9 @@ def download_file_from_drive(file_id, output_path):
     If the file is a native Google document (e.g. a spreadsheet), it will be
     exported to a suitable format before saving locally.
     """
+    if not file_id:
+        raise ValueError("file_id é obrigatório para realizar o download")
+
     service = authenticate_service()
 
     meta = service.files().get(fileId=file_id, fields="mimeType,name").execute()


### PR DESCRIPTION
## Summary
- abort Drive download when file ID is missing
- document `TERMS_FILE_ID` environment variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883f051d48c83219d77cdcbd855a61f