### PR TITLE
Fix drive folder ID logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ docker run --rm -v $PWD:/app scraperdou
 - `servicescraperdou.json` (não subir no GitHub)
 - `credentials.json` (não subir no GitHub)
 - Variável de ambiente `TERMS_FILE_ID` com o ID da planilha de termos no Google Drive
+- Variável de ambiente `GOOGLE_DRIVE_FOLDER_ID` (ou `DRIVE_FOLDER_ID`/`FOLDER_ID`) com o ID da pasta de destino no Google Drive
 
 **Importante:** Verifique permissões e IDs de arquivos/pastas usados no Google Drive.


### PR DESCRIPTION
## Summary
- allow `FOLDER_ID` env var as a fallback for Google Drive folder
- add logging and support for shared drives in `drive_uploader`
- document Google Drive folder env variable in README

## Testing
- `python -m py_compile drive_uploader.py main.py main_teste.py scraper.py cleanup_utils.py report_utils.py pdf_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f48581c48321a1005cb792ac3f59