### PR TITLE
Fix service account path in workflow

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -28,7 +28,7 @@ jobs:
           GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
           TERMS_FILE_ID: ${{ secrets.TERMS_FILE_ID }}
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
-          SERVICE_ACCOUNT_FILE: servicescraperdou.json
+          SERVICE_ACCOUNT_FILE: service_account.json
         run: |
           echo "$SERVICE_ACCOUNT_JSON" | base64 --decode > "$SERVICE_ACCOUNT_FILE"
           python main.py


### PR DESCRIPTION
## Summary
- ensure GitHub Actions workflow decodes credentials to the filename expected by the code

## Testing
- `python -m py_compile drive_uploader.py main.py main_teste.py cleanup_utils.py scraper.py pdf_utils.py report_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6888ab6ce1688321bcdaf6d6f7a6c5a6