### PR TITLE
Fix env var fallback for Drive uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ docker run --rm -v $PWD:/app scraperdou
 - `servicescraperdou.json` (não subir no GitHub)
 - `credentials.json` (não subir no GitHub)
 - Variável de ambiente `TERMS_FILE_ID` com o ID da planilha de termos no Google Drive
-- Variável de ambiente `GOOGLE_DRIVE_FOLDER_ID` (ou `DRIVE_FOLDER_ID`/`FOLDER_ID`) com o ID da pasta de destino no Google Drive
+- Variável de ambiente `GOOGLE_DRIVE_FOLDER_ID` (ou `DRIVE_FOLDER_ID`/`FOLDER_ID`) com o ID da pasta de destino no Google Drive. O script lê automaticamente nessas três variáveis, nesta ordem.
 
 **Importante:** Verifique permissões e IDs de arquivos/pastas usados no Google Drive.

--- a/drive_uploader.py
+++ b/drive_uploader.py
@@ -15,7 +15,12 @@ def authenticate_service():
     return build("drive", "v3", credentials=credentials)
 
 service = authenticate_service()
-DRIVE_FOLDER_ID = os.getenv("FOLDER_ID")  # Suporta Meu Drive ou Shared Drive
+# Aceita diferentes nomes de variáveis de ambiente para maior flexibilidade
+DRIVE_FOLDER_ID = (
+    os.getenv("GOOGLE_DRIVE_FOLDER_ID")
+    or os.getenv("DRIVE_FOLDER_ID")
+    or os.getenv("FOLDER_ID")
+)
 
 def upload_to_drive(file_path, mime_type="application/pdf"):
     file_metadata = {


### PR DESCRIPTION
## Summary
- support `GOOGLE_DRIVE_FOLDER_ID` and `DRIVE_FOLDER_ID` env vars
- document folder id env var fallback order

## Testing
- `python -m py_compile drive_uploader.py main.py main_teste.py cleanup_utils.py report_utils.py scraper.py pdf_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6888b5a3e7188321b169feb297bf5a11