### PR TITLE
Add domain delegation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ docker run --rm -v $PWD:/app scraperdou
 - `credentials.json` (não subir no GitHub)
 - Variável de ambiente `TERMS_FILE_ID` com o ID da planilha de termos no Google Drive
 - Variável de ambiente `GOOGLE_DRIVE_FOLDER_ID` (ou `DRIVE_FOLDER_ID`/`FOLDER_ID`) com o ID da pasta de destino no Google Drive. O script lê automaticamente nessas três variáveis, nesta ordem.
+- `DELEGATE_EMAIL` com o email a ser impersonado se estiver usando uma conta de serviço com delegação de domínio
 
 **Importante:** Verifique permissões e IDs de arquivos/pastas usados no Google Drive.

--- a/drive_uploader.py
+++ b/drive_uploader.py
@@ -7,11 +7,14 @@ from google.oauth2 import service_account
 
 SCOPES = ["https://www.googleapis.com/auth/drive"]
 SERVICE_ACCOUNT_FILE = os.getenv("SERVICE_ACCOUNT_FILE", "servicescraperdou.json")
+DELEGATE_EMAIL = os.getenv("DELEGATE_EMAIL")
 
 # Autenticação
 def authenticate_service():
     credentials = service_account.Credentials.from_service_account_file(
         SERVICE_ACCOUNT_FILE, scopes=SCOPES)
+    if DELEGATE_EMAIL:
+        credentials = credentials.with_subject(DELEGATE_EMAIL)
     return build("drive", "v3", credentials=credentials)
 
 service = authenticate_service()


### PR DESCRIPTION
## Summary
- allow Drive uploads using domain delegation by impersonating a user
- document `DELEGATE_EMAIL` variable

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888b7f332388321b739d5d0bc318b8a