### PR TITLE
Add GitHub upload step

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,8 @@ docker run --rm -v $PWD:/app scraperdou
 - Variável de ambiente `TERMS_FILE_ID` com o ID da planilha de termos no Google Drive
 - Variável de ambiente `GOOGLE_DRIVE_FOLDER_ID` (ou `DRIVE_FOLDER_ID`/`FOLDER_ID`) com o ID da pasta de destino no Google Drive. O script lê automaticamente nessas três variáveis, nesta ordem.
 - `DELEGATE_EMAIL` com o email a ser impersonado se estiver usando uma conta de serviço com delegação de domínio
+- `GITHUB_TOKEN` token pessoal para autenticar no GitHub
+- `GITHUB_REPO` no formato `usuario/repositorio` onde os arquivos serão enviados
+- `GITHUB_BRANCH` (opcional) branch onde os arquivos serão adicionados, padrão `main`
 
 **Importante:** Verifique permissões e IDs de arquivos/pastas usados no Google Drive.

--- a/github_utils.py
+++ b/github_utils.py
@@ -1,0 +1,47 @@
+import base64
+import logging
+import os
+import requests
+
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+GITHUB_REPO = os.getenv("GITHUB_REPO")
+GITHUB_BRANCH = os.getenv("GITHUB_BRANCH", "main")
+
+
+def upload_file_to_github(file_path, repo_path=None, message="Add highlighted PDF"):
+    """Envia um arquivo para um repositório do GitHub via API REST."""
+    if not GITHUB_TOKEN or not GITHUB_REPO:
+        logging.error("Variáveis GITHUB_TOKEN ou GITHUB_REPO não configuradas")
+        return None
+
+    repo_path = repo_path or os.path.basename(file_path)
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/contents/{repo_path}"
+
+    with open(file_path, "rb") as f:
+        content = base64.b64encode(f.read()).decode("utf-8")
+
+    headers = {
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+    }
+
+    params = {"ref": GITHUB_BRANCH}
+    resp = requests.get(url, headers=headers, params=params)
+    sha = resp.json().get("sha") if resp.status_code == 200 else None
+
+    payload = {
+        "message": message,
+        "branch": GITHUB_BRANCH,
+        "content": content,
+    }
+    if sha:
+        payload["sha"] = sha
+
+    resp = requests.put(url, headers=headers, json=payload)
+    if resp.status_code not in (200, 201):
+        logging.error("Erro ao enviar para o GitHub: %s", resp.text)
+        return None
+
+    html_url = resp.json().get("content", {}).get("html_url")
+    logging.info("Arquivo enviado para o GitHub em %s", html_url)
+    return html_url

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 import pandas as pd
 from scraper import DOUScraper
 from drive_uploader import upload_to_drive, download_file_from_drive, list_files_in_drive
+from github_utils import upload_file_to_github
 from cleanup_utils import cleanup_local_files
 import requests
 from io import BytesIO
@@ -60,11 +61,19 @@ def main():
         link = upload_to_drive(highlighted_pdf_path)
         logging.info(f"PDF com destaque enviado para o Google Drive: {link}")
 
+        github_link = upload_file_to_github(highlighted_pdf_path)
+        if github_link:
+            logging.info(f"PDF com destaque salvo no GitHub: {github_link}")
+
         report_path = os.path.join(download_dir, "search_report.xlsx")
         if os.path.exists(report_path):
             logging.info(f"Upload do relatório: {report_path}")
             report_link = upload_to_drive(report_path)
             logging.info(f"Relatório enviado para o Google Drive: {report_link}")
+
+            github_report = upload_file_to_github(report_path)
+            if github_report:
+                logging.info(f"Relatório salvo no GitHub: {github_report}")
         else:
             logging.warning(f"Arquivo de relatório não encontrado: {report_path}")
 


### PR DESCRIPTION
## Summary
- upload files directly to GitHub using REST API
- call GitHub uploader from main workflow
- document new environment variables for GitHub configuration

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888cbed27388321bee5878d634b4383