### PR TITLE
Switch to GitHub upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Scraper DOU
 
 Este projeto automatiza o download, análise e envio de PDFs do Diário Oficial da União (DOU).
+Os resultados (PDF destacado e relatório) agora são versionados diretamente no repositório GitHub configurado.
+O Google Drive é utilizado apenas para baixar a planilha de termos, caso um `TERMS_FILE_ID` seja fornecido.
 
 ## Requisitos
 - Docker instalado
@@ -23,10 +25,11 @@ docker run --rm -v $PWD:/app scraperdou
 - `servicescraperdou.json` (não subir no GitHub)
 - `credentials.json` (não subir no GitHub)
 - Variável de ambiente `TERMS_FILE_ID` com o ID da planilha de termos no Google Drive
-- Variável de ambiente `GOOGLE_DRIVE_FOLDER_ID` (ou `DRIVE_FOLDER_ID`/`FOLDER_ID`) com o ID da pasta de destino no Google Drive. O script lê automaticamente nessas três variáveis, nesta ordem.
+- (Opcional) `GOOGLE_DRIVE_FOLDER_ID` (ou `DRIVE_FOLDER_ID`/`FOLDER_ID`) caso deseje listar arquivos ou baixar a planilha de termos a partir do Google Drive
 - `DELEGATE_EMAIL` com o email a ser impersonado se estiver usando uma conta de serviço com delegação de domínio
 - `GITHUB_TOKEN` token pessoal para autenticar no GitHub
 - `GITHUB_REPO` no formato `usuario/repositorio` onde os arquivos serão enviados
 - `GITHUB_BRANCH` (opcional) branch onde os arquivos serão adicionados, padrão `main`
+- `TARGET_REPO` e `TARGET_BRANCH` podem ser usados como sinônimos de `GITHUB_REPO` e `GITHUB_BRANCH`
 
 **Importante:** Verifique permissões e IDs de arquivos/pastas usados no Google Drive.

--- a/github_utils.py
+++ b/github_utils.py
@@ -4,8 +4,8 @@ import os
 import requests
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
-GITHUB_REPO = os.getenv("GITHUB_REPO")
-GITHUB_BRANCH = os.getenv("GITHUB_BRANCH", "main")
+GITHUB_REPO = os.getenv("GITHUB_REPO") or os.getenv("TARGET_REPO")
+GITHUB_BRANCH = os.getenv("GITHUB_BRANCH") or os.getenv("TARGET_BRANCH") or "main"
 
 
 def upload_file_to_github(file_path, repo_path=None, message="Add highlighted PDF"):

--- a/main.py
+++ b/main.py
@@ -3,12 +3,9 @@ import logging
 import os
 import pandas as pd
 from scraper import DOUScraper
-from drive_uploader import upload_to_drive, download_file_from_drive, list_files_in_drive
+from drive_uploader import download_file_from_drive, list_files_in_drive
 from github_utils import upload_file_to_github
 from cleanup_utils import cleanup_local_files
-import requests
-from io import BytesIO
-from time import sleep
 from dotenv import load_dotenv
 
 # Carrega variáveis de ambiente
@@ -57,20 +54,14 @@ def main():
         scraper.navigate_and_download(terms_df)
 
         highlighted_pdf_path = scraper.pdf_path.replace(".pdf", "_highlighted.pdf")
-        logging.info(f"Upload do PDF destacado: {highlighted_pdf_path}")
-        link = upload_to_drive(highlighted_pdf_path)
-        logging.info(f"PDF com destaque enviado para o Google Drive: {link}")
-
+        logging.info(f"Enviando PDF destacado para o GitHub: {highlighted_pdf_path}")
         github_link = upload_file_to_github(highlighted_pdf_path)
         if github_link:
             logging.info(f"PDF com destaque salvo no GitHub: {github_link}")
 
         report_path = os.path.join(download_dir, "search_report.xlsx")
         if os.path.exists(report_path):
-            logging.info(f"Upload do relatório: {report_path}")
-            report_link = upload_to_drive(report_path)
-            logging.info(f"Relatório enviado para o Google Drive: {report_link}")
-
+            logging.info(f"Enviando relatório para o GitHub: {report_path}")
             github_report = upload_file_to_github(report_path)
             if github_report:
                 logging.info(f"Relatório salvo no GitHub: {github_report}")


### PR DESCRIPTION
## Summary
- stop uploading highlighted PDFs to Google Drive
- upload files only to GitHub
- support TARGET_REPO/TARGET_BRANCH env vars
- clarify README about GitHub usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888daf6e8f08321b286e7a6234724c0