### PR TITLE
Improve logging and add GitHub upload fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,7 @@ docker run --rm -v $PWD:/app scraperdou
 - `GITHUB_REPO` no formato `usuario/repositorio` onde os arquivos serão enviados
 - `GITHUB_BRANCH` (opcional) branch onde os arquivos serão adicionados, padrão `main`
 - `TARGET_REPO` e `TARGET_BRANCH` podem ser usados como sinônimos de `GITHUB_REPO` e `GITHUB_BRANCH`
+- `LOG_LEVEL` define o nível de log (padrão `DEBUG`)
+- `LOCAL_OUTPUT_DIR` pasta onde os arquivos são salvos caso o envio para o GitHub falhe (padrão `output_files`)
 
 **Importante:** Verifique permissões e IDs de arquivos/pastas usados no Google Drive.

--- a/github_utils.py
+++ b/github_utils.py
@@ -1,21 +1,33 @@
 import base64
 import logging
 import os
+import shutil
 import requests
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 GITHUB_REPO = os.getenv("GITHUB_REPO") or os.getenv("TARGET_REPO")
 GITHUB_BRANCH = os.getenv("GITHUB_BRANCH") or os.getenv("TARGET_BRANCH") or "main"
+LOCAL_OUTPUT_DIR = os.getenv("LOCAL_OUTPUT_DIR", "output_files")
+
+
+def save_file_locally(file_path, dest_dir=LOCAL_OUTPUT_DIR):
+    """Salva uma cópia do arquivo no diretório especificado."""
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_path = os.path.join(dest_dir, os.path.basename(file_path))
+    shutil.copy(file_path, dest_path)
+    logging.info("Arquivo salvo localmente em %s", dest_path)
+    return dest_path
 
 
 def upload_file_to_github(file_path, repo_path=None, message="Add highlighted PDF"):
     """Envia um arquivo para um repositório do GitHub via API REST."""
     if not GITHUB_TOKEN or not GITHUB_REPO:
         logging.error("Variáveis GITHUB_TOKEN ou GITHUB_REPO não configuradas")
-        return None
+        return save_file_locally(file_path)
 
     repo_path = repo_path or os.path.basename(file_path)
     url = f"https://api.github.com/repos/{GITHUB_REPO}/contents/{repo_path}"
+    logging.debug("Enviando %s para %s em %s", file_path, GITHUB_REPO, GITHUB_BRANCH)
 
     with open(file_path, "rb") as f:
         content = base64.b64encode(f.read()).decode("utf-8")
@@ -27,6 +39,7 @@ def upload_file_to_github(file_path, repo_path=None, message="Add highlighted PD
 
     params = {"ref": GITHUB_BRANCH}
     resp = requests.get(url, headers=headers, params=params)
+    logging.debug("GET %s -> %s", url, resp.status_code)
     sha = resp.json().get("sha") if resp.status_code == 200 else None
 
     payload = {
@@ -38,9 +51,10 @@ def upload_file_to_github(file_path, repo_path=None, message="Add highlighted PD
         payload["sha"] = sha
 
     resp = requests.put(url, headers=headers, json=payload)
+    logging.debug("PUT %s -> %s", url, resp.status_code)
     if resp.status_code not in (200, 201):
         logging.error("Erro ao enviar para o GitHub: %s", resp.text)
-        return None
+        return save_file_locally(file_path)
 
     html_url = resp.json().get("content", {}).get("html_url")
     logging.info("Arquivo enviado para o GitHub em %s", html_url)

--- a/main.py
+++ b/main.py
@@ -11,9 +11,10 @@ from dotenv import load_dotenv
 # Carrega variáveis de ambiente
 load_dotenv()
 
+log_level = os.getenv("LOG_LEVEL", "DEBUG").upper()
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
+    level=getattr(logging, log_level, logging.DEBUG),
+    format='%(asctime)s - %(levelname)s - %(name)s:%(lineno)d - %(message)s',
     handlers=[
         logging.FileHandler('dou_scraper.log'),
         logging.StreamHandler()


### PR DESCRIPTION
## Summary
- log level now configurable via `LOG_LEVEL` (defaults to DEBUG)
- if GitHub upload fails, save files to `LOCAL_OUTPUT_DIR` (defaults to `output_files`)
- add detailed debug logs for GitHub requests
- document new variables

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f0859cd08321a9eedbd9a3414576