### PR TITLE
Fix PDF output directory

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,8 @@ def main():
     logging.info("Lendo a planilha de termos")
     terms_df = pd.read_excel(local_excel_path, engine="openpyxl")
 
-    download_dir = os.getcwd()
+    download_dir = os.path.join(os.getcwd(), "PDF")
+    os.makedirs(download_dir, exist_ok=True)
     scraper = DOUScraper(download_dir)
 
     try:


### PR DESCRIPTION
## Summary
- save downloaded files inside the `PDF` folder

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6889050cbefc8321bacc5810629fc871